### PR TITLE
main: allow secretless tokens

### DIFF
--- a/mutt_oauth2/main.py
+++ b/mutt_oauth2/main.py
@@ -76,7 +76,7 @@ def main(username: str,
                                             type=click.Choice(['google', 'microsoft']))),
                            email=click.prompt('Account e-mail address'),
                            client_id=click.prompt('Client ID'),
-                           client_secret=click.prompt('Client secret'))
+                           client_secret=click.prompt('Client secret', default='') or None)
         log.debug('Settings thus far: %s', token.as_json(indent=2))
         if token.registration.tenant is not None:  # pragma: no cover
             token.tenant = click.prompt('Tenant', default=token.registration.tenant)


### PR DESCRIPTION
[oauth2 has improved supports for native apps](https://datatracker.ietf.org/doc/rfc8252/) which drop the required client secret (which was easily leaked anyway). this is more and more used nowdays and seems to be required for (new?) micro$oft accounts.